### PR TITLE
Add media_player.bravia_command service for sending arbitrary commands

### DIFF
--- a/custom_components/braviatv_psk/media_player.py
+++ b/custom_components/braviatv_psk/media_player.py
@@ -11,18 +11,18 @@ from homeassistant.components.media_player import (
     MediaPlayerDevice, PLATFORM_SCHEMA)
 try:
     from homeassistant.components.media_player.const import (
-        SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
+        DOMAIN, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
         SUPPORT_TURN_ON, SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_PLAY,
         SUPPORT_PLAY_MEDIA, SUPPORT_VOLUME_STEP, SUPPORT_VOLUME_SET,
         SUPPORT_SELECT_SOURCE, SUPPORT_STOP, MEDIA_TYPE_TVSHOW)
 except ImportError:
     from homeassistant.components.media_player import (
-        SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
+        DOMAIN, SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
         SUPPORT_TURN_ON, SUPPORT_TURN_OFF, SUPPORT_VOLUME_MUTE, SUPPORT_PLAY,
         SUPPORT_PLAY_MEDIA, SUPPORT_VOLUME_STEP, SUPPORT_VOLUME_SET,
         SUPPORT_SELECT_SOURCE, SUPPORT_STOP, MEDIA_TYPE_TVSHOW)
 from homeassistant.const import (
-    CONF_HOST, CONF_NAME, CONF_MAC, STATE_OFF, STATE_ON)
+    ATTR_ENTITY_ID, CONF_HOST, CONF_NAME, CONF_MAC, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
 __version__ = '0.3.1'
@@ -69,6 +69,15 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SOURCE_FILTER, default=[]): vol.All(
         cv.ensure_list, [cv.string])})
 
+SERVICE_BRAVIA_COMMAND = 'bravia_command'
+
+ATTR_COMMAND_ID = 'command_id'
+
+BRAVIA_COMMAND_SCHEMA = vol.Schema({
+    vol.Optional(ATTR_ENTITY_ID): cv.entity_id,
+    vol.Required(ATTR_COMMAND_ID): cv.string,
+})
+
 # pylint: disable=unused-argument
 
 
@@ -87,8 +96,13 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
             "No TV IP address or Pre-Shared Key found in configuration file")
         return
 
-    add_devices(
-        [BraviaTVDevice(host, psk, mac, name, amp, android, source_filter)])
+    device = BraviaTVDevice(host, psk, mac, name, amp, android, source_filter)
+    add_devices([device])
+
+    hass.services.register(
+        DOMAIN, SERVICE_BRAVIA_COMMAND,
+        lambda service: device.send_command(service.data[ATTR_COMMAND_ID]),
+        schema=BRAVIA_COMMAND_SCHEMA)
 
 
 class BraviaTVDevice(MediaPlayerDevice):
@@ -402,3 +416,7 @@ class BraviaTVDevice(MediaPlayerDevice):
             self._braviarc.send_command(media_id)
         else:
             _LOGGER.warning("Unsupported media_id: %s", media_id)
+
+    def send_command(self, command_id):
+        """Send arbitrary command to TV."""
+        self._braviarc.send_command(command_id)

--- a/custom_components/braviatv_psk/services.yaml
+++ b/custom_components/braviatv_psk/services.yaml
@@ -1,0 +1,9 @@
+bravia_command:
+  description: Send a custom command to Bravia TV.
+  fields:
+    entity_id:
+      description: Name(s) of entities to turn on.
+      example: 'media_player.bravia_tv'
+    command_id:
+      description: The ID of the command to send to TV.
+      example: 'ChannelUp'


### PR DESCRIPTION
As some TVs support many more commands that the existing API exposes
(for example Assistant, Subtitle, Action Menu, Picture Menu, etc.),
let user send any command she wants. Useful for creating virtual remote
control for example.

I don't think "services.yaml" file gets picked up but probably would
when having this as an official component.