### PR TITLE
Android power off command

### DIFF
--- a/custom_components/braviatv_psk/manifest.json
+++ b/custom_components/braviatv_psk/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bravia TV PSK",
   "documentation": "https://github.com/custom-components/media_player.braviatv_psk",
   "requirements": [
-    "pySonyBraviaPSK==0.1.8"
+    "pySonyBraviaPSK==0.1.9"
   ],
   "dependencies": [],
   "codeowners": [

--- a/custom_components/braviatv_psk/media_player.py
+++ b/custom_components/braviatv_psk/media_player.py
@@ -329,9 +329,16 @@ class BraviaTVDevice(MediaPlayerDevice):
         self._program_name = TV_WAIT
 
     def turn_off(self):
-        """Turn off media player."""
-        self._braviarc.turn_off()
-        self._state = STATE_OFF
+        """Turn the media player off.
+
+        Use a different command for Android since IRCC is not working reliable.
+        """
+        if self._android:
+            self._braviarc.turn_off_command()
+            self._state = STATE_OFF
+        else:
+            self._braviarc.turn_off()
+            self._state = STATE_OFF
 
     def volume_up(self):
         """Volume up the media player."""

--- a/custom_components/braviatv_psk/media_player.py
+++ b/custom_components/braviatv_psk/media_player.py
@@ -335,10 +335,10 @@ class BraviaTVDevice(MediaPlayerDevice):
         """
         if self._android:
             self._braviarc.turn_off_command()
-            self._state = STATE_OFF
         else:
             self._braviarc.turn_off()
-            self._state = STATE_OFF
+
+        self._state = STATE_OFF
 
     def volume_up(self):
         """Volume up the media player."""


### PR DESCRIPTION
This PR implements a different logic to turn off Bravia televisions running android.
This PR is dependent on [PR#14](https://github.com/gerard33/sony_bravia_psk/pull/14/)