### PR TITLE
Renamed MediaPlayerDevice to MediaPlayer entity

### DIFF
--- a/custom_components/braviatv_psk/media_player.py
+++ b/custom_components/braviatv_psk/media_player.py
@@ -7,8 +7,10 @@ https://github.com/custom-components/media_player.braviatv_psk
 import logging
 import voluptuous as vol
 
-from homeassistant.components.media_player import (
-    MediaPlayerDevice, PLATFORM_SCHEMA)
+try:
+    from homeassistant.components.media_player import (MediaPlayerEntity, PLATFORM_SCHEMA)
+except ImportError:
+    from homeassistant.components.media_player import (MediaPlayerDevice as MediaPlayerEntity, PLATFORM_SCHEMA)
 try:
     from homeassistant.components.media_player.const import (
         SUPPORT_NEXT_TRACK, SUPPORT_PAUSE, SUPPORT_PREVIOUS_TRACK,
@@ -25,7 +27,7 @@ from homeassistant.const import (
     CONF_HOST, CONF_NAME, CONF_MAC, STATE_OFF, STATE_ON)
 import homeassistant.helpers.config_validation as cv
 
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 
 REQUIREMENTS = ['pySonyBraviaPSK==0.1.9']
 
@@ -109,14 +111,14 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
         return
 
     add_devices(
-        [BraviaTVDevice(host, psk, mac, name, amp, android, source_filter, time_format)])
+        [BraviaTVEntity(host, psk, mac, name, amp, android, source_filter, time_format)])
 
 
-class BraviaTVDevice(MediaPlayerDevice):
+class BraviaTVEntity(MediaPlayerEntity):
     """Representation of a Sony Bravia TV."""
 
     def __init__(self, host, psk, mac, name, amp, android, source_filter, time_format):
-        """Initialize the Sony Bravia device."""
+        """Initialize the Sony Bravia entity."""
         _LOGGER.info("Setting up Sony Bravia TV")
         from braviapsk import sony_bravia_psk
 
@@ -235,17 +237,17 @@ class BraviaTVDevice(MediaPlayerDevice):
 
     @property
     def name(self):
-        """Return the name of the device."""
+        """Return the name of the entity."""
         return self._name
 
     @property
     def unique_id(self):
-        """Return the unique ID of the device."""
+        """Return the unique ID of the entity."""
         return self._unique_id
 
     @property
     def state(self):
-        """Return the state of the device."""
+        """Return the state of the entity."""
         return self._state
 
     @property


### PR DESCRIPTION
When running the beta of HA 0.110 I came across the following message:

`2020-05-15 08:17:03 WARNING (MainThread) [homeassistant.components.media_player] MediaPlayerDevice is deprecated, modify BraviaTVDevice to extend MediaPlayerEntity
`

Last night the following blog appeared
[https://developers.home-assistant.io/blog/2020/05/14/entity-class-names](url)