### PR TITLE
Enable Refresh Channels to be done during standby as well as active

### DIFF
--- a/custom_components/braviatv_psk/media_player.py
+++ b/custom_components/braviatv_psk/media_player.py
@@ -340,10 +340,11 @@ class BraviaTVEntity(MediaPlayerEntity):
             power_status = await self.hass.async_add_executor_job(
                 self._braviarc.get_power_status
             )
+            if power_status in ["active", "standby"]:
+                await self._async_refresh_channels()
             if power_status == "active":
                 self._state = STATE_ON
                 await self._async_refresh_volume()
-                await self._async_refresh_channels()
                 playing_info = await self.hass.async_add_executor_job(
                     self._braviarc.get_playing_info
                 )


### PR DESCRIPTION
I'm getting spurious 404 errors from the load_source_list logic in pySonyBraviaPSK. 

There seems to have been some change in either HA or Sony firmware which is causing more error conditions (possibly race conditions) from the TV. You will see the proposal I have put in for pySonyBraviaPSK as well.

The challenge here is that channel refresh is a one time operation, currently when TV is active and when HA has been restarted. Quite often this will be the first time the TV has been switched on after an HA restart. 

The idea of this change is to reduce the risk of a race condition (where the channel info is requested when the TV is busy switching on), since the channel list info is also available when the TV is is standby (or at least on my 2021 model it is).